### PR TITLE
GitHub linguist now supports .vy syntax natively

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-*.vy linguist-language=Python


### PR DESCRIPTION
Add Vyper smart contract language #5778
https://github.com/github/linguist/pull/5778

Example of live syntax highlighting (provided that `.gitattributes` with `*.vy linguist-language=Python` is not present)
https://github.com/vyperlang/vyper/blob/master/examples/tokens/ERC20.vy
https://github.com/vyperlang/vyper/blob/master/examples/crowdfund.vy